### PR TITLE
Skipping deprecated behavior

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,7 +45,7 @@ export async function markdowner(
 ): Promise<any> {
   let renderer = remark()
     .use(slug)
-    .use(autolinkHeadings, { behaviour: 'wrap' })
+    .use(autolinkHeadings, { behavior: 'wrap' })
     .use(inlineLinks)
     .use(emoji)
     .use([hljs, html], { sanitize: false })


### PR DESCRIPTION
"behaviour" has been deprecated in `remark-autolink-headings` and replaced with "behavior".  (see: https://github.com/remarkjs/remark-autolink-headings/commit/73a977f46cc2dc90b0641f09fb5ed4b6a50d84ae)

This PR uses the newly named parameter to avoid a unnecessary warning in the console.