### PR TITLE
Missing dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "gray-matter": "^4.0.2",
     "hasha": "^5.0.0",
+    "json-stable-stringify": "^1.0.1",
     "remark": "^10.0.1",
     "remark-autolink-headings": "^5.1.0",
     "remark-gemoji-to-emoji": "^1.1.0",
@@ -37,7 +38,6 @@
     "codecov": "^3.2.0",
     "jest": "^25.1.0",
     "jest-junit": "^10.0.0",
-    "json-stable-stringify": "^1.0.1",
     "level": "^6.0.0",
     "semantic-release": "^17.0.0",
     "ts-jest": "^25.0.0",


### PR DESCRIPTION
The `json-stable-stringify` dependency is required for `smhmarkdowner` to work but it is not part of the dependencies. This PR moves `json-stable-stringfy` from dev- to regular dependencies.