### PR TITLE
fix: removing "level" from peer-dependency to avoid warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "remark-slug": "^5.1.1",
     "remark-toc": "^7.0.0"
   },
-  "peerDependencies": {
-    "level": "^6.0.0"
-  },
   "devDependencies": {
     "@types/jest": "^25.1.0",
     "@types/json-stable-stringify": "^1.0.32",


### PR DESCRIPTION
`npm WARN smh-markdowner@2.2.0 requires a peer of level@^6.0.0 but none is installed. You must install peer dependencies yourself.`

... is _inaccurate-ish_ as markdowner doesn't need leveldb to work and has no require statements that require level. This PR removes the peer-dependency for not showing the message.